### PR TITLE
Add client ID to Client struct and update Hub to use string keys for clients

### DIFF
--- a/internal/realtime/client.go
+++ b/internal/realtime/client.go
@@ -14,10 +14,9 @@ const (
 )
 
 type Client struct {
-	hub *Hub
-
+	ID   string
+	hub  *Hub
 	conn *websocket.Conn
-
 	send chan []byte
 }
 

--- a/internal/realtime/manager.go
+++ b/internal/realtime/manager.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/pasanAbeysekara/collaborative-editor/internal/auth"
 	"github.com/pasanAbeysekara/collaborative-editor/internal/storage"
@@ -102,11 +103,16 @@ func (m *Manager) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := &Client{hub: hub, conn: conn, send: make(chan []byte, 256)}
+	client := &Client{
+		ID:   uuid.NewString(),
+		hub:  hub,
+		conn: conn,
+		send: make(chan []byte, 256),
+	}
 	client.hub.register <- client
 
 	go client.writePump()
 	go client.readPump()
 
-	log.Printf("Client for user %s connected to hub for document %s", userID, documentID)
+	log.Printf("Client %s (for user %s) connected to hub for document %s", client.ID, userID, documentID)
 }


### PR DESCRIPTION
- #10

Introduce a unique client ID to the Client struct and modify the Hub to manage clients using string keys instead of pointers. This change enhances client identification and improves the handling of client connections.