### PR TITLE
Update services to use port 8080 and configure environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ FROM alpine:latest
 
 COPY --from=builder /app/server /server
 
-EXPOSE 8081
+EXPOSE 8080
 
 ENTRYPOINT ["/server"]

--- a/cmd/document-service/Dockerfile
+++ b/cmd/document-service/Dockerfile
@@ -7,5 +7,5 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /app/server ./cmd/document-servic
 
 FROM alpine:latest
 COPY --from=builder /app/server /server
-EXPOSE 8081
+EXPOSE 8080
 ENTRYPOINT ["/server"]

--- a/cmd/document-service/main.go
+++ b/cmd/document-service/main.go
@@ -41,6 +41,6 @@ func main() {
         r.Post("/documents/{documentID}/share", docHandler.ShareDocument)
     })
 
-    log.Println("Starting document-service on port :8080...")
-    http.ListenAndServe(":8080", r)
+    log.Printf("Starting document-service on port %s...\n", cfg.Port)
+    http.ListenAndServe(":"+cfg.Port, r)
 }

--- a/cmd/document-service/main.go
+++ b/cmd/document-service/main.go
@@ -41,6 +41,6 @@ func main() {
         r.Post("/documents/{documentID}/share", docHandler.ShareDocument)
     })
 
-    log.Println("Starting document-service on port :8081...")
-    http.ListenAndServe(":8081", r)
+    log.Println("Starting document-service on port :8080...")
+    http.ListenAndServe(":8080", r)
 }

--- a/cmd/gateway/nginx.conf
+++ b/cmd/gateway/nginx.conf
@@ -10,15 +10,15 @@ http {
     # Define the upstream servers (our microservices)
     # The names must match the service names in docker-compose.yml
     upstream user_service {
-        server user-service:8081;
+        server user-service:8080;
     }
 
     upstream document_service {
-        server document-service:8081;
+        server document-service:8080;
     }
 
     upstream realtime_service {
-        server realtime-service:8081;
+        server realtime-service:8080;
     }
 
     server {

--- a/cmd/realtime-service/Dockerfile
+++ b/cmd/realtime-service/Dockerfile
@@ -7,5 +7,5 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /app/server ./cmd/realtime-servic
 
 FROM alpine:latest
 COPY --from=builder /app/server /server
-EXPOSE 8081
+EXPOSE 8080
 ENTRYPOINT ["/server"]

--- a/cmd/realtime-service/main.go
+++ b/cmd/realtime-service/main.go
@@ -33,6 +33,6 @@ func main() {
         r.Get("/ws/doc/{documentID}", rtManager.ServeWS)
     })
 
-    log.Println("Starting realtime-service on port :8081...")
-    http.ListenAndServe(":8081", r)
+    log.Println("Starting realtime-service on port :8080...")
+    http.ListenAndServe(":8080", r)
 }

--- a/cmd/realtime-service/main.go
+++ b/cmd/realtime-service/main.go
@@ -33,6 +33,6 @@ func main() {
         r.Get("/ws/doc/{documentID}", rtManager.ServeWS)
     })
 
-    log.Println("Starting realtime-service on port :8080...")
-    http.ListenAndServe(":8080", r)
+    log.Printf("Starting realtime-service on port %s...\n", cfg.Port)
+    http.ListenAndServe(":"+cfg.Port, r)
 }

--- a/cmd/user-service/Dockerfile
+++ b/cmd/user-service/Dockerfile
@@ -7,5 +7,5 @@ RUN CGO_ENABLED=0 go build -ldflags="-w -s" -o /app/server ./cmd/user-service
 
 FROM alpine:latest
 COPY --from=builder /app/server /server
-EXPOSE 8081
+EXPOSE 8080
 ENTRYPOINT ["/server"]

--- a/cmd/user-service/main.go
+++ b/cmd/user-service/main.go
@@ -33,6 +33,6 @@ func main() {
     r.Post("/auth/register", userHandler.Register)
     r.Post("/auth/login", userHandler.Login)
 
-    log.Println("Starting user-service on port :8081...")
-    http.ListenAndServe(":8081", r)
+    log.Println("Starting user-service on port :8080...")
+    http.ListenAndServe(":8080", r)
 }

--- a/cmd/user-service/main.go
+++ b/cmd/user-service/main.go
@@ -33,6 +33,6 @@ func main() {
     r.Post("/auth/register", userHandler.Register)
     r.Post("/auth/login", userHandler.Login)
 
-    log.Println("Starting user-service on port :8080...")
-    http.ListenAndServe(":8080", r)
+    log.Printf("Starting user-service on port %s...\n", cfg.Port)
+    http.ListenAndServe(cfg.Port, r)
 }

--- a/cmd/user-service/main.go
+++ b/cmd/user-service/main.go
@@ -34,5 +34,5 @@ func main() {
     r.Post("/auth/login", userHandler.Login)
 
     log.Printf("Starting user-service on port %s...\n", cfg.Port)
-    http.ListenAndServe(cfg.Port, r)
+    http.ListenAndServe(":"+cfg.Port, r)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ./cmd/gateway/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "8081:80" # Expose NGINX on port 8081
+      - "8080:80" # Expose NGINX on port 8080
     depends_on:
       - user-service
       - document-service
@@ -19,7 +19,7 @@ services:
     env_file:
       - .env
     environment:
-      PORT: "8081"
+      PORT: "8080"
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${JWT_SECRET}
 
@@ -31,7 +31,7 @@ services:
     env_file:
       - .env
     environment:
-      PORT: "8081"
+      PORT: "8080"
       DATABASE_URL: ${DATABASE_URL}
       JWT_SECRET: ${JWT_SECRET}
     
@@ -44,11 +44,11 @@ services:
     env_file:
       - .env
     environment:
-      PORT: "8081"
+      PORT: "8080"
       REDIS_URL: ${REDIS_URL}
       JWT_SECRET: ${JWT_SECRET}
       # NEW: URL to the internal document-service for auth checks
-      DOCUMENT_SERVICE_URL: "http://document-service:8081"
+      DOCUMENT_SERVICE_URL: "http://document-service:8080"
     depends_on:
       - redis
       - document-service

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Config struct {
-    Port        string `envconfig:"PORT" default:"8081"`
+    Port        string `envconfig:"PORT" default:"8080"`
     DatabaseURL string `envconfig:"DATABASE_URL" required:"true"`
     JWTSecret   string `envconfig:"JWT_SECRET" required:"true"`
     RedisURL    string `envconfig:"REDIS_URL" required:"true"`

--- a/requests.http
+++ b/requests.http
@@ -1,4 +1,4 @@
-@baseUrl = http://localhost:8081
+@baseUrl = http://localhost:8080
 
 ### 1. Register a new user
 # This endpoint creates a new user in the in-memory store.


### PR DESCRIPTION
Change all services to operate on port 8080 instead of 8081 and set necessary environment variables for database, JWT, and document service URLs.