### PR TITLE
Enhance WebSocket API documentation and deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,10 +283,8 @@ The OpenAPI specification can be used with:
 The documentation is kept in sync with the actual API implementation and includes all the latest features and validation rules.
 
 ## WebSocket API
-=======
----
 
-## Testing the System
+### Testing the System
 
 All interaction with the application now goes through the Minikube Ingress IP.
 

--- a/deployed_setup.sh
+++ b/deployed_setup.sh
@@ -1,0 +1,19 @@
+export SOURCE_URL=miniature-system-vww9j7vqj7ghp5g9-8080.app.github.dev
+
+echo -e "\n--- 2. Logging in Users ---"
+export TOKEN_A=$(curl -s -X POST -H "Content-Type: application/json" -d '{"email":"owner@example.com", "password":"password123"}' https://$SOURCE_URL/auth/login | jq -r .token)
+export TOKEN_B=$(curl -s -X POST -H "Content-Type: application/json" -d '{"email":"collab@example.com", "password":"password123"}' https://$SOURCE_URL/auth/login | jq -r .token)
+
+echo "--- 3. Creating Document ---"
+export DOCUMENT_ID=$(curl -s -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN_A" -d '{"title":"Live Test Doc"}' https://$SOURCE_URL/documents | jq -r .ID)
+
+echo "--- 4. Sharing Document ---"
+curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN_A" -d '{"email":"collab@example.com", "role":"editor"}' https://$SOURCE_URL/documents/$DOCUMENT_ID/share
+
+echo -e "\n\n✅ Setup Complete! Use these exported variables for WebSocket testing:"
+echo "------------------------------------------------------------------"
+echo "export SOURCE_URL=$SOURCE_URL"
+echo "export DOCUMENT_ID=$DOCUMENT_ID"
+echo "export TOKEN_A=$TOKEN_A"
+echo "export TOKEN_B=$TOKEN_B"
+echo "------------------------------------------------------------------"

--- a/internal/realtime/manager.go
+++ b/internal/realtime/manager.go
@@ -22,6 +22,11 @@ var upgrader = websocket.Upgrader{
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
+		
+		if origin == "" {
+			return true
+		}
+		
 		allowedOrigins := []string{
 			"https://solid-guide-974w6599qrjgfpr9j-5174.app.github.dev",
 			"http://localhost:3000",


### PR DESCRIPTION
Update the README to clarify the WebSocket API and testing instructions. Add a deployment setup script for user login and document sharing. Allow empty origin in WebSocket CheckOrigin for better compatibility.