### PR TITLE
Include version in initial state message for synchronization improvements

### DIFF
--- a/internal/realtime/hub.go
+++ b/internal/realtime/hub.go
@@ -71,6 +71,7 @@ func (h *Hub) run() {
 			initialStateMsg := &ServerMessage{
 				Type:    MsgInitialState,
 				Content: h.content,
+				Version: h.version,
 			}
 			select {
 			case client.send <- initialStateMsg:

--- a/internal/realtime/operation.go
+++ b/internal/realtime/operation.go
@@ -13,6 +13,7 @@ const (
 type ServerMessage struct {
 	Type    ServerMessageType `json:"type"`
 	Content string            `json:"content,omitempty"` // For initial state
+	Version int               `json:"version,omitempty"` // <<< ADD THIS LINE
 	Op      *Operation        `json:"op,omitempty"`      // For operations
 }
 


### PR DESCRIPTION
Add a version field to the initial state message to enhance synchronization between the server and clients.